### PR TITLE
Update SlipOscBridgeFunctions.py so that malformed SLIP messages are discarded

### DIFF
--- a/SlipOscBridgeFunctions.py
+++ b/SlipOscBridgeFunctions.py
@@ -80,7 +80,7 @@ def serialInHandler():
                             msg = message[1:len(message)-1] # remove beginning and trailing END characters
                             if not (msg.endswith(ESC) or re.search(ESC + b'[^' + ESC_END + ESC_ESC + b']', msg)):
                                 serial2OscQueue.put(msg.replace(ESC + ESC_END, END).replace(ESC + ESC_ESC, ESC))
-                                message = b'' #next message
+                            message = b'' #next message
     # close SerialPort after stopping
     del serialPort
 


### PR DESCRIPTION
Thank you for the excellent tool! But I did find a bug!
If there is a malformed SLIP message the buffer keeps on filling up and no more messages can be processed anymore.
The OSC message is : /pot (int)

Bug : https://pasteboard.co/mWhxAHkHYNdB.png

Bug fixed: https://pasteboard.co/J27Nk4b2vpoU.png

